### PR TITLE
Use icloud.com endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ would export something like this as `CARDDAV_ENDPOINT`:
 export CARDDAV_ENDPOINT='https://my.baik.al/dav.php/'
 ```
 
+If you're using iCloud for example, you would eport something like this as `CARDDAV_ENDPOINT`:
+
+```sh
+export CARDDAV_ENDPOINT='https://contacts.icloud.com/<DSID>/carddavhome/card/'
+```
+
 The `ADDRB_DB` is the local contacts database in order to not need to contact
 the CardDAV for every lookup. You might set it to something like this:
 

--- a/dav/dav.go
+++ b/dav/dav.go
@@ -3,6 +3,7 @@ package dav
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/emersion/go-vcard"
 	"github.com/emersion/go-webdav"
@@ -41,14 +42,18 @@ func New(endpoint, username, password string) (*DAV, error) {
 		return nil, err
 	}
 
-	dav.addrbookHomeSet, err =
-		dav.cdClient.FindAddressBookHomeSet(
-			context.Background(),
-			fmt.Sprintf("principals/%s",
-				dav.username,
-			))
-	if err != nil {
-		return dav, err
+	if strings.HasSuffix(dav.endpoint, ".icloud.com") {
+		dav.addrbookHomeSet = dav.endpoint
+	} else {
+		dav.addrbookHomeSet, err =
+			dav.cdClient.FindAddressBookHomeSet(
+				context.Background(),
+				fmt.Sprintf("principals/%s",
+					dav.username,
+				))
+		if err != nil {
+			return dav, err
+		}
 	}
 
 	dav.addrbooks, err =


### PR DESCRIPTION
iCloud employs a highly specific URL that incorporates the user’s account ID (DSID). This patch enables `addrb` to directly use the `$CARDDAV_ENDPOINT`.

Another option is to set a boolean environment variable that allows direct use of the endpoint url.